### PR TITLE
Add GPU path tracing renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Run and deploy your AI Studio app
 
-This contains everything you need to run your app locally.
+This contains everything you need to run your app locally. The application now uses the
+`three-gpu-pathtracer` library to render a scene with GPU path tracing.
 
 ## Run Locally
 

--- a/index.html
+++ b/index.html
@@ -5,14 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>3D City Walker</title>
     <link rel="stylesheet" href="index.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
 </head>
 <body>
     <canvas id="webglCanvas"></canvas>
     <div id="controls-info">
-        On Foot: W, A, S, D to move. Space to Jump. Mouse to look. <br>
-        Press 'F' near car to Enter/Exit. <br>
-        In Car: W (Accelerate), S (Brake/Reverse), A (Steer Left), D (Steer Right).
+        Rendering scene with GPU path tracing.
     </div>
     <script type="module" src="./src/main.ts"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,11 @@
     "": {
       "name": "3d-city-walker",
       "version": "0.0.0",
+      "dependencies": {
+        "three": "^0.177.0",
+        "three-gpu-pathtracer": "^0.0.23",
+        "three-stdlib": "^2.36.0"
+      },
       "devDependencies": {
         "@types/node": "^22.14.0",
         "typescript": "~5.7.2",
@@ -718,6 +723,12 @@
         "win32"
       ]
     },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
@@ -734,6 +745,24 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.22.tgz",
+      "integrity": "sha512-Vr6Stjv5jPRqH690f5I5GLjVk8GSsoQSYJ2FVd/3jJF7KaqfwPi3ehfBS96mlQ2kPCwZaX6U0rG2+NGHBKkA/A==",
+      "license": "MIT"
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/esbuild": {
       "version": "0.25.5",
@@ -790,6 +819,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -874,6 +909,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
+    },
     "node_modules/rollup": {
       "version": "4.43.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.43.0.tgz",
@@ -922,6 +963,50 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.177.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.177.0.tgz",
+      "integrity": "sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg==",
+      "license": "MIT"
+    },
+    "node_modules/three-gpu-pathtracer": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/three-gpu-pathtracer/-/three-gpu-pathtracer-0.0.23.tgz",
+      "integrity": "sha512-CjMX5YU3ajDklOv3hW1EQ4CCkPLiLR+jB31w6G5WLf6Nasemib62tmCj45vBK5ItKAD0aHG1NWc479gXzk6fOQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.151.0",
+        "three-mesh-bvh": ">=0.7.4",
+        "xatlas-web": "^0.1.0"
+      }
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.9.0.tgz",
+      "integrity": "sha512-xAwZj0hZknpwVsdK5BBJTIAZDjDPZCRzURY1o+z/JHBON/jc2UetK1CzPeQZiiOVSfI4jV2z7sXnnGtgsgnjaA==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.36.0",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.0.tgz",
+      "integrity": "sha512-kv0Byb++AXztEGsULgMAs8U2jgUdz6HPpAB/wDJnLiLlaWQX2APHhiTJIN7rqW+Of0eRgcp7jn05U1BsCP3xBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
       }
     },
     "node_modules/tinyglobby": {
@@ -1036,6 +1121,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xatlas-web": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xatlas-web/-/xatlas-web-0.1.0.tgz",
+      "integrity": "sha512-PprVfuXbaIskxLTLBUQRaWfgSy9xUQqAMIRooOw0P6NYqwgh6T0voeer6+Z5M7AFt5SGXUybuww/uDGs1yw8vQ==",
+      "license": "MIT",
+      "peer": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-
+    "three": "^0.177.0",
+    "three-gpu-pathtracer": "^0.0.23",
+    "three-stdlib": "^2.36.0"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/src/RaytracingWorld.ts
+++ b/src/RaytracingWorld.ts
@@ -1,0 +1,66 @@
+import * as THREE from 'three';
+import { WebGLPathTracer, PhysicalPathTracingMaterial, BlurredEnvMapGenerator, GradientEquirectTexture } from 'three-gpu-pathtracer';
+
+export class RaytracingWorld {
+  private renderer: THREE.WebGLRenderer;
+  private camera: THREE.PerspectiveCamera;
+  private scene: THREE.Scene;
+  private pathTracer: WebGLPathTracer;
+
+  constructor(canvasId = 'webglCanvas') {
+    const canvas = document.getElementById(canvasId) as HTMLCanvasElement;
+    this.renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+    this.renderer.setSize(window.innerWidth, window.innerHeight);
+    this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    this.scene = new THREE.Scene();
+
+    this.camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
+    this.camera.position.set(0, 1.5, 4);
+
+    this.pathTracer = new WebGLPathTracer(this.renderer);
+    this.pathTracer.setScene(this.scene, this.camera);
+
+    this.initScene();
+    this.onResize();
+    window.addEventListener('resize', () => this.onResize());
+    requestAnimationFrame(() => this.animate());
+  }
+
+  private initScene() {
+    const floorGeo = new THREE.BoxGeometry(10, 0.1, 10);
+    const floorMat = new PhysicalPathTracingMaterial();
+    floorMat.color.set(0x808080);
+    const floor = new THREE.Mesh(floorGeo, floorMat);
+    floor.position.y = -0.05;
+    this.scene.add(floor);
+
+    const sphereGeo = new THREE.SphereGeometry(1, 64, 32);
+    const sphereMat = new PhysicalPathTracingMaterial();
+    sphereMat.metalness = 1.0;
+    sphereMat.roughness = 0.2;
+    sphereMat.color.set(0x999999);
+    const sphere = new THREE.Mesh(sphereGeo, sphereMat);
+    sphere.position.set(0, 1, 0);
+    this.scene.add(sphere);
+
+    // Environment map for better lighting
+    const generator = new BlurredEnvMapGenerator(this.renderer);
+    const gradient = new GradientEquirectTexture();
+    gradient.topColor = new THREE.Color(0xffffff);
+    gradient.bottomColor = new THREE.Color(0x888888);
+    gradient.update();
+    const blurred = generator.generate(gradient, 0.35);
+    this.scene.environment = blurred;
+  }
+
+  private onResize() {
+    this.camera.aspect = window.innerWidth / window.innerHeight;
+    this.camera.updateProjectionMatrix();
+    this.renderer.setSize(window.innerWidth, window.innerHeight);
+  }
+
+  private animate() {
+    requestAnimationFrame(() => this.animate());
+    this.pathTracer.renderSample();
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,16 +1,4 @@
-import { BasicWorld } from './BasicWorld';
+import { RaytracingWorld } from './RaytracingWorld';
 
-if (typeof THREE !== 'undefined') {
-  new BasicWorld();
-} else {
-  console.error('Three.js has not been loaded.');
-  const canvas = document.getElementById('webglCanvas') as HTMLCanvasElement | null;
-  if (canvas) {
-    const ctx = canvas.getContext('2d');
-    if (ctx) {
-      ctx.fillStyle = 'red';
-      ctx.font = '16px Arial';
-      ctx.fillText('Error: Three.js failed to load. Check CDN link.', 10, 50);
-    }
-  }
-}
+// Initialize the path-traced scene
+new RaytracingWorld();


### PR DESCRIPTION
## Summary
- integrate `three` packages and `three-gpu-pathtracer`
- implement `RaytracingWorld` using GPU path tracing
- use the new world as the app entry
- update HTML to remove CDN and show new info
- document the new renderer in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68512933f7fc8327b4d18d38afee13d7