### PR TITLE
Add animated character and bigger reflective city

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Run and deploy your AI Studio app
 
-This contains everything you need to run your app locally. The application now uses the
-`three-gpu-pathtracer` library to render a scene with GPU path tracing.
+This contains everything you need to run your app locally. The application now uses
+an interactive 3D scene with a larger city, reflective buildings and an animated
+character.
 
 ## Run Locally
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { RaytracingWorld } from './RaytracingWorld';
+import { BasicWorld } from './BasicWorld';
 
-// Initialize the path-traced scene
-new RaytracingWorld();
+// Initialize the interactive scene
+new BasicWorld();


### PR DESCRIPTION
## Summary
- replace path-traced demo with a large interactive city
- load an animated GLTF model for the player
- use remote textures for streets, ground and buildings
- make buildings reflective and add reflective spheres around the city
- update README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68512c4bf7b48327938019b84e2ad2bd